### PR TITLE
Fixed typo for "CliClickPath"

### DIFF
--- a/AutoCydiaImpactor.scpt
+++ b/AutoCydiaImpactor.scpt
@@ -61,7 +61,7 @@ log "Clicking on Device at m:" & realXPosition & "," & realYPosition & " dc:" & 
 tell application "System Events" to tell process "Impactor"
 	click button 1 of combo box 2 of window "Cydia Impactor"
 end tell
-do shell script ClicClickPath & " m:" & realXPosition & "," & realYPosition & " dc:" & realXPosition & "," & realYPosition
+do shell script CliClickPath & " m:" & realXPosition & "," & realYPosition & " dc:" & realXPosition & "," & realYPosition
 delay 0.25
 
 log "Launching Install Package... menu"


### PR DESCRIPTION
Removed an additional "c" from the variable that caused the script to fail.